### PR TITLE
Quote urls in Cargo.nix

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -537,7 +537,7 @@ in
     version = "0.1.0";
     registry = "git+https://github.com/euank/serde-nix.git";
     src = fetchCrateGit {
-      url = https://github.com/euank/serde-nix.git;
+      url = "https://github.com/euank/serde-nix.git";
       name = "serde-nix";
       version = "0.1.0";
       rev = "1e3d04d88dcbec91d0aec050a4a53cd5e8c5e2d4";};


### PR DESCRIPTION
As URL literals are deprecated: https://github.com/NixOS/rfcs/blob/master/rfcs/0045-deprecate-url-syntax.md

Manually adding this as the fix in cargo2nix isn't yet released: https://github.com/cargo2nix/cargo2nix/pull/357